### PR TITLE
feat: add keyboard shortcuts for answer selection

### DIFF
--- a/src/components/Questions/Questions.jsx
+++ b/src/components/Questions/Questions.jsx
@@ -11,6 +11,7 @@ import ThemeOverlay from 'components/Shared/ThemeOverlay';
 import PlayerContext from 'contexts/PlayerContext';
 import AlwaysScrollToBottom from 'components/Shared/Scrolling/AlwaysScrollToBottom';
 import { Trans } from 'react-i18next';
+import { buildComboString } from 'components/Shared/Form/FormikHotkeyInput/FormikHotkeyInput';
 import Answer from './Answer';
 import Timer from './Timer/Timer';
 import GameOver from './GameOver';
@@ -95,6 +96,43 @@ const Questions = ({ questions }) => {
       setTimeout(() => solve(option), 2000);
     }
   };
+
+  useEffect(() => {
+    if (!gameSettings.enableKeyboardShortcuts) return;
+
+    const handleKeyDown = (e) => {
+      if (isLocked) return;
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement.tagName)) {
+        return;
+      }
+
+      const combo = buildComboString(e);
+      const shortcutMap = {
+        [gameSettings.shortcutA]: 'a',
+        [gameSettings.shortcutB]: 'b',
+        [gameSettings.shortcutC]: 'c',
+        [gameSettings.shortcutD]: 'd',
+      };
+
+      if (shortcutMap[combo]) {
+        handleChoice(shortcutMap[combo])();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line consistent-return
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    gameSettings.enableKeyboardShortcuts,
+    gameSettings.shortcutA,
+    gameSettings.shortcutB,
+    gameSettings.shortcutC,
+    gameSettings.shortcutD,
+    isLocked,
+    handleChoice,
+  ]);
 
   return isOver || !activeQuestion ? (<GameOver endGameButton={endGame} isWinner={!activeQuestion} />) : (
     <>

--- a/src/components/Settings/AppSettings/AppSettings.jsx
+++ b/src/components/Settings/AppSettings/AppSettings.jsx
@@ -6,6 +6,7 @@ import {useContext, useRef} from 'react';
 import GameSettingsContext from 'contexts/GameSettingsContext';
 import FormikSwitch from 'components/Shared/Form/FormikSwitch/FormikSwitch';
 import FormikInput from 'components/Shared/Form/FormikInput/FormikInput';
+import FormikHotkeyInput from 'components/Shared/Form/FormikHotkeyInput/FormikHotkeyInput';
 import PropTypes from 'prop-types';
 import ReactGA from 'react-ga4';
 import AppSettingsValidationSchema from './AppSettingsValidationSchema';
@@ -21,11 +22,12 @@ const AppSettings = ({ submitRef, setShowModal }) => {
   const nonSwitchSettings = {};
 
   inputSettings.forEach(({ name, type }) => {
+    const isHotkey = type === 'hotkey';
     nonSwitchSettings[name] = {
-      Component: FormikInput,
+      Component: isHotkey ? FormikHotkeyInput : FormikInput,
       props: {
         name,
-        type,
+        ...(!isHotkey && { type }),
         label: t(name),
       },
     };

--- a/src/components/Settings/AppSettings/AppSettingsValidationSchema.jsx
+++ b/src/components/Settings/AppSettings/AppSettingsValidationSchema.jsx
@@ -12,6 +12,11 @@ const AppSettingsValidationSchema = Yup.object().shape({
     .integer(validationMessages.mustBeIntegerNumber)
     .min(1, validationMessages.minNumber(1))
     .max(999, validationMessages.maxNumber(999)),
+  enableKeyboardShortcuts: Yup.bool().required(validationMessages.requiredField),
+  shortcutA: Yup.string().required(validationMessages.requiredField),
+  shortcutB: Yup.string().required(validationMessages.requiredField),
+  shortcutC: Yup.string().required(validationMessages.requiredField),
+  shortcutD: Yup.string().required(validationMessages.requiredField),
 });
 
 export default AppSettingsValidationSchema;

--- a/src/components/Shared/Form/FormikHotkeyInput/FormikHotkeyInput.css
+++ b/src/components/Shared/Form/FormikHotkeyInput/FormikHotkeyInput.css
@@ -1,0 +1,13 @@
+.hotkey-input {
+  cursor: pointer;
+  caret-color: transparent;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.hotkey-input:focus,
+.hotkey-recording {
+  outline: 2px solid #0d6efd;
+  outline-offset: -1px;
+}

--- a/src/components/Shared/Form/FormikHotkeyInput/FormikHotkeyInput.jsx
+++ b/src/components/Shared/Form/FormikHotkeyInput/FormikHotkeyInput.jsx
@@ -1,0 +1,80 @@
+import { Form, InputGroup } from 'react-bootstrap';
+import { Field } from 'formik';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import FormikErrorMessage from '../FormikErrorMessage/FormikErrorMessage';
+import './FormikHotkeyInput.css';
+
+const MODIFIER_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta']);
+
+const buildComboString = (e) => {
+  const parts = [];
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.altKey) parts.push('Alt');
+  if (e.shiftKey) parts.push('Shift');
+  if (e.metaKey) parts.push('Meta');
+
+  const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+  if (!MODIFIER_KEYS.has(key)) {
+    parts.push(key);
+  }
+  return parts.join('+');
+};
+
+const FormikHotkeyInput = ({
+  name, label, showError, disabled,
+}) => {
+  const [recording, setRecording] = useState(false);
+
+  return (
+    <Field name={name}>
+      {({ field, form, meta }) => {
+        const onKeyDown = (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (MODIFIER_KEYS.has(e.key)) return;
+          const combo = buildComboString(e);
+          form.setFieldValue(name, combo);
+          setRecording(false);
+          e.target.blur();
+        };
+
+        return (
+          <div className="mb-3">
+            <InputGroup>
+              <InputGroup.Text htmlFor={name}>{label}</InputGroup.Text>
+              <Form.Control
+                id={name}
+                type="text"
+                readOnly
+                value={recording ? '...' : field.value}
+                onFocus={() => setRecording(true)}
+                onBlur={() => setRecording(false)}
+                onKeyDown={onKeyDown}
+                isInvalid={meta.touched && meta.error}
+                disabled={disabled}
+                className={`hotkey-input${recording ? ' hotkey-recording' : ''}`}
+              />
+            </InputGroup>
+            {showError && <FormikErrorMessage name={name} />}
+          </div>
+        );
+      }}
+    </Field>
+  );
+};
+
+FormikHotkeyInput.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  showError: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+FormikHotkeyInput.defaultProps = {
+  showError: true,
+  disabled: false,
+};
+
+export { buildComboString };
+export default FormikHotkeyInput;

--- a/src/contexts/GameSettingsContext.jsx
+++ b/src/contexts/GameSettingsContext.jsx
@@ -3,13 +3,20 @@ import PropTypes from 'prop-types';
 
 const dependentChildren = {
   enableTimer: ['timerCountDown'],
+  enableKeyboardShortcuts: ['shortcutA', 'shortcutB', 'shortcutC', 'shortcutD'],
 };
 
 const switchSettings = [
-  'stopGameLose', 'continueGameWrongAnswer', 'enableSounds', 'enableTimer',
+  'stopGameLose', 'continueGameWrongAnswer', 'enableSounds', 'enableTimer', 'enableKeyboardShortcuts',
 ];
 
-const inputSettings = [{ name: 'timerCountDown', type: 'number' }];
+const inputSettings = [
+  { name: 'timerCountDown', type: 'number' },
+  { name: 'shortcutA', type: 'hotkey' },
+  { name: 'shortcutB', type: 'hotkey' },
+  { name: 'shortcutC', type: 'hotkey' },
+  { name: 'shortcutD', type: 'hotkey' },
+];
 
 const savedSettings = JSON.parse(localStorage.getItem('settings'));
 const defaultValue = {
@@ -19,6 +26,11 @@ const defaultValue = {
     enableSounds: savedSettings?.enableSounds ?? true,
     enableTimer: savedSettings?.enableTimer ?? true,
     timerCountDown: savedSettings?.timerCountDown ?? 30,
+    enableKeyboardShortcuts: savedSettings?.enableKeyboardShortcuts ?? true,
+    shortcutA: savedSettings?.shortcutA ?? 'Shift+A',
+    shortcutB: savedSettings?.shortcutB ?? 'Shift+B',
+    shortcutC: savedSettings?.shortcutC ?? 'Shift+C',
+    shortcutD: savedSettings?.shortcutD ?? 'Shift+D',
   },
   dependentChildren,
   switchSettings,
@@ -40,6 +52,11 @@ const GameSettingsProvider = ({ children }) => {
       enableSounds: settings.enableSounds,
       enableTimer: settings.enableTimer,
       timerCountDown: settings.timerCountDown,
+      enableKeyboardShortcuts: settings.enableKeyboardShortcuts,
+      shortcutA: settings.shortcutA,
+      shortcutB: settings.shortcutB,
+      shortcutC: settings.shortcutC,
+      shortcutD: settings.shortcutD,
     };
     setGameSettings(values);
     localStorage.setItem('settings', JSON.stringify(values));

--- a/src/locales/ar/settings.json
+++ b/src/locales/ar/settings.json
@@ -6,6 +6,11 @@
     "continueGameWrongAnswer": "اكمل اللعب مع اظهار الاجابة الصحيحة",
     "enableSounds": "تشغيل اصوات اللعبة",
     "enableTimer": "تشغيل المؤقت",
-    "timerCountDown": "تحديد وقت المؤقت (بالثواني)"
+    "timerCountDown": "تحديد وقت المؤقت (بالثواني)",
+    "enableKeyboardShortcuts": "تشغيل اختصارات لوحة المفاتيح",
+    "shortcutA": "اختصار الاجابة أ",
+    "shortcutB": "اختصار الاجابة ب",
+    "shortcutC": "اختصار الاجابة ج",
+    "shortcutD": "اختصار الاجابة د"
   }
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -6,6 +6,11 @@
     "continueGameWrongAnswer": "Continue game showing wrong answer",
     "enableSounds": "Enable game sounds",
     "enableTimer": "Enable Timer",
-    "timerCountDown": "Set timer time (in seconds)"
+    "timerCountDown": "Set timer time (in seconds)",
+    "enableKeyboardShortcuts": "Enable keyboard shortcuts",
+    "shortcutA": "Shortcut for answer A",
+    "shortcutB": "Shortcut for answer B",
+    "shortcutC": "Shortcut for answer C",
+    "shortcutD": "Shortcut for answer D"
   }
 }


### PR DESCRIPTION
- Add enableKeyboardShortcuts toggle (default ON) in GameSettingsContext
- Add shortcutA/B/C/D hotkey fields with defaults Shift+A through Shift+D
- Create FormikHotkeyInput component for recording key combinations
- Render hotkey inputs under the keyboard shortcuts toggle in AppSettings
- Add keydown listener in Questions.jsx to trigger answer selection
- Guard against firing when inputs are focused or when locked
- Add i18n keys for en/ar (enableKeyboardShortcuts, shortcutA/B/C/D)
- Persist all settings to localStorage